### PR TITLE
fix 404 error in pdf preview of workshop slides

### DIFF
--- a/kempner_computing_handbook/_config.yml
+++ b/kempner_computing_handbook/_config.yml
@@ -28,7 +28,10 @@ html:
   extra_js:
     - _static/custom.js
   google_analytics_id: G-QFZEXWFW26
+  extra_static_paths: 
+   - _static
   static_path: ["_static"]
+
 
 exclude_patterns:
   - scalability/distributed_computing.md

--- a/kempner_computing_handbook/s9_workshops_and_trainings/intro_to_kempner_ai_cluster/intro_to_kempner_ai_cluster.md
+++ b/kempner_computing_handbook/s9_workshops_and_trainings/intro_to_kempner_ai_cluster/intro_to_kempner_ai_cluster.md
@@ -13,5 +13,5 @@ To view the "Introduction to the Kempner AI cluster" workshop slides (in pdf for
 {download}`Introduction to Kempner AI cluster Workshop </_static/workshop/Intro_to_Kempner_AI_Cluster_Workshop.pdf>`
 
 <div style="text-align: center;">
-  <iframe src="/kempner_computing_handbook/_static/workshop/Intro_to_Kempner_AI_Cluster_Workshop.pdf" width="90%" height="460px" style="border: none;"></iframe>
+ <iframe src="/_static/workshop/Intro_to_Kempner_AI_Cluster_Workshop.pdf" width="90%" height="460px" style="border: none;"></iframe>
 </div>


### PR DESCRIPTION
## Description

Fix [Issue 167](https://github.com/KempnerInstitute/kempner-computing-handbook/issues/167) - resolve 404 File Not Found error in pdf preview of the Intro to Kempner AI Cluster slides

## Checklist

Before submitting this PR, please confirm that you have completed the following:

- [ x] I have checked the submission for spelling and grammatical errors.
- x[ ] I have built the JupyterBook locally, and the build was successful.
- [x ] I have linked the related issue in this PR (if applicable).
- [x ] I have checked that all links and references in the book are working.
- [ x] I have ensured that all cross-references are according to the guidelines.
- [ x] I have verified that the new content follows the existing structure and style guidelines.
- [ x] I have tested the changes in both light and dark mode (if applicable).
- [ x] I have reviewed and resolved any warnings or errors shown during the JupyterBook build.
- [ x] I have ensured that images, figures, and tables render correctly and are appropriately captioned.

## Related Issues

Fixes [Issue 167](https://github.com/KempnerInstitute/kempner-computing-handbook/issues/167) 

## Notes for Reviewers


