### PR TITLE
copyright data fix

### DIFF
--- a/kempner_computing_handbook/_config.yml
+++ b/kempner_computing_handbook/_config.yml
@@ -1,5 +1,5 @@
 title: Kempner Institute Computing Handbook
-copyright: " 2024, The President and Fellows of Harvard College"
+copyright: " 2025, The President and Fellows of Harvard College"
 author: Kempner Institute
 logo: figures/svg/Kempner-logo_Full-Color-Full-Name-Harvard.svg
 execute:


### PR DESCRIPTION
changed 2024 to 2025

## Description

This PR fixes CopyRight date fix (2024 -> 2025).

## Checklist

Before submitting this PR, please confirm that you have completed the following:

- [x] I have read and followed the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked the submission for spelling and grammatical errors.
- [x] I have built the JupyterBook locally, and the build was successful.
- [x] I have linked the related issue in this PR (if applicable).
- [x] I have checked that all links and references in the book are working.
- [x] I have ensured that all cross-references are according to the guidelines.
- [x] I have verified that the new content follows the existing structure and style guidelines.
- [x] I have tested the changes in both light and dark mode (if applicable).
- [x] I have reviewed and resolved any warnings or errors shown during the JupyterBook build.
- [x] I have ensured that images, figures, and tables render correctly and are appropriately captioned.

## Related Issues

<!-- Mention related issues here. Example: Fixes #123, Closes #456 -->

Closes #199 

## Notes for Reviewers

None
