### PR TITLE
Restore data management pages to table of contents

### DIFF
--- a/kempner_computing_handbook/_toc.yml
+++ b/kempner_computing_handbook/_toc.yml
@@ -37,6 +37,8 @@ parts:
       - file: s1_high_performance_computing/storage_and_data_transfer/understanding_storage_options
       - file: s1_high_performance_computing/storage_and_data_transfer/data_transfer
       - file: s1_high_performance_computing/storage_and_data_transfer/shared_data_repository
+      - file: s1_high_performance_computing/storage_and_data_transfer/data_management_plan
+      - file: s1_high_performance_computing/storage_and_data_transfer/data_management_plan_faq
     # - file: s1_high_performance_computing/efficient_use_of_resources/README
       # sections:
       # - file: s1_high_performance_computing/efficient_use_of_resources/best_practices_for_hpc_efficiency


### PR DESCRIPTION
Closes #335.

The `data_management_plan` and `data_management_plan_faq` pages under `s1_high_performance_computing/storage_and_data_transfer/` existed in the source tree but were missing from `_toc.yml`, so the build emitted "document isn't included in any toctree" for both and the pages did not appear in the book navigation. A later edit to `_toc.yml` had dropped the two lines.

This re-adds the two entries under the Storage and Data Transfer section (after `shared_data_repository`). The local build is now clean with no toctree warnings. Only `_toc.yml` is changed (+2 lines).