### PR TITLE
Disable fuzzy autolinking in MyST config

### DIFF
--- a/kempner_computing_handbook/_config.yml
+++ b/kempner_computing_handbook/_config.yml
@@ -39,3 +39,10 @@ exclude_patterns:
   - s9_workshops_and_trainings/workshops/*
   - s9_workshops_and_trainings/intro_to_hpc/*
   - s5_ai_scaling_and_engineering/scalability/distributed_computing.md
+
+# Disable fuzzy (schemeless) autolinking so text like "coverage.py" is not
+# turned into a link (".py" etc. are real TLDs). Full URLs and explicit
+# [text](url) links are unaffected.
+sphinx:
+  config:
+    myst_linkify_fuzzy_links: false


### PR DESCRIPTION
Closes #337.

MyST's `linkify` extension was auto-linking bare, schemeless text that resembles a domain. Because many file/package suffixes are real top-level domains (`.py` is Paraguay, plus `.io`, `.sh`, `.md`, and others), tokens such as `coverage.py` rendered as links to bogus URLs (`http://coverage.py`), and bare domains in prose linked over `http://`.

This sets `myst_linkify_fuzzy_links: false` via `sphinx: config:` in `_config.yml`. Schemeless text is no longer auto-linked, while full `https://` URLs and explicit `[text](url)` links are unaffected.

Verified locally: with the setting on, the resolved MyST config reports `linkify_fuzzy_links=False`, the previously bogus `http://` autolinks disappear, and real links still render. Only `_config.yml` is changed (+7 lines).