### PR TITLE
Add figure format standard to the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,38 +123,38 @@ Done!
 If you are contributing figures to the handbook, please make sure to follow these guidelines:
 
 - Each chapter, has a folder in the `kempner_computing_handbook` directory. Inside each chapter folder, there is a `figures` folder with subfolder for each figure type (e.g., `ai`, `png`, `svg`, `pdf`, etc.). Please make sure to place your figures in the appropriate folder.
-- We require the use of vector graphics (e.g., SVG, PDF) for figures, as they are scalable without loss of quality and facilitate easy editing. If, due to specific constraints, you must include raster graphics (e.g., PNG, JPG), please provide a detailed explanation in your pull request justifying their necessity. Ensure that any raster images are of high resolution (minimum 300 dpi) to maintain visual clarity in the handbook.
+- Prefer vector graphics (e.g., SVG, PDF) for hand-drawn or annotated diagrams, since they scale without loss of quality and are easy to edit. Programmatically generated figures (e.g., with Matplotlib) may be exported as high-resolution PNG following the style guidelines below. For photographs or scans, justify the raster use in your pull request and use a high resolution (at least 300 dpi).
 - If you are annotating a figure, please include both the original and the annotated figures. If you are using Adobe Illustrator to annotate figures (recommended), please include the `.ai` file. This will facilitate the change of the figure's annotation style to make it uniform in the handbook.  
 - Please avoid using copyrighted images or figures that are not licensed for reuse. If you are using figures from external sources, make sure to provide proper attribution and licensing information in the figure caption or in the text. As a contributor, you are solely responsible for ensuring that your submission does not violate any copyright laws.
 
 ### Style and formatting guidelines for figures
 
-If you are creating new figures, please make sure to follow the style and formatting guidelines of the handbook to ensure consistency across the chapters.
+If you are creating new figures, please follow the style guidelines below so figures stay consistent across chapters. A machine-readable version of these settings, for scripts that generate figures, lives in [`kempner_computing_handbook/figures/figure-format.json`](kempner_computing_handbook/figures/figure-format.json).
 
 **Font**:
 
-- **Font Type**: Use Arial for all text within figures. 
-- **Font Size**: Set the font size to 12 pt for standard text. 
+- **Font Type**: Use a clean sans-serif font. Programmatically generated figures may use the Matplotlib default (DejaVu Sans); Arial is an acceptable equivalent. 
+- **Font Size**: Keep text large enough to read at the figure's displayed size, and avoid very small labels. 
 
 **Color Palette**:
 
-- **Primary Colors**: TBD
-- **Secondary Colors**:TBD
-- **Accent Colors**: TBD
+- **Primary**: Navy `#14154C`, for titles, key labels, borders, and dark fills.
+- **Secondary**: periwinkle `#C6C8F4`. For multi-category figures, use the navy-to-periwinkle ramp `#14154C`, `#3D3E82`, `#6A6CB8`, `#A9ABE4` (white text on the darker steps, navy text on the lighter steps).
+- **Accent**: Harvard Crimson `#A51C30`, used sparingly for highlights and a single focal element.
 
-**Figure Size and Aspect Ratio**:
+**Size, Aspect Ratio, and Resolution**:
 
-- **Size**: Design figures with a width of `800` pixels and a height of `600` pixels. 
-- **Aspect Ratio**: Maintain a `4:3` aspect ratio to ensure uniformity throughout the handbook. 
+- **Size**: Size figures for legibility rather than a fixed dimension; a width of roughly 1600 to 2200 pixels renders crisply on the web. 
+- **Aspect Ratio and Resolution**: Choose an aspect ratio that suits the content. Export programmatically generated raster figures at about 200 dpi (Matplotlib), which yields images around 2000 pixels wide. 
 
 **Figure Caption**:
 
-- **Placement**: DO NOT include figure caption in the figure itself.
+- **Placement**: Keep the descriptive caption in the page text, not baked into the image, so it stays accessible and editable. A short title inside the figure is fine.
 - **Content**: Figure caption should be concise, informative, and self-sufficient. Readers should be able to understand the figure without referring to the text.
 
 **Background Color**: 
 
-- Use transparent background for figures to ensure that they blend seamlessly with the handbook's design. 
+- Use the light lavender canvas `#F4F5FC` for a consistent branded background. A transparent background is also fine when a figure should blend directly into the page. 
 
 
 ## Contributing a Workshop Session

--- a/kempner_computing_handbook/figures/figure-format.json
+++ b/kempner_computing_handbook/figures/figure-format.json
@@ -1,5 +1,5 @@
 {
-  "description": "Figure format standard for the Kempner Institute Computing Handbook. Apply these settings when creating original figures so they share a consistent, on-brand look. Prefer original figures over copyrighted images.",
+  "description": "Machine-readable figure style standard for the Kempner Institute Computing Handbook, and the companion to the figures section of CONTRIBUTING.md. Apply these settings when creating original figures so they share a consistent, on-brand look. Prefer original figures over copyrighted images.",
   "brand_colors": {
     "navy": "#14154C",
     "crimson": "#A51C30",
@@ -7,7 +7,7 @@
     "background": "#F4F5FC"
   },
   "brand_color_notes": {
-    "navy": "Primary color, from the Kempner logo. Use for titles, key labels, borders, and dark fills.",
+    "navy": "Primary color. Use for titles, key labels, borders, and dark fills.",
     "crimson": "Harvard Crimson, the accent color. Use sparingly for highlights, emphasis, and a single focal element.",
     "periwinkle": "Light tint, matches the handbook caption background. Use for light fills and light text backgrounds.",
     "background": "Very light lavender canvas applied behind the whole figure."
@@ -31,7 +31,7 @@
   },
   "page_usage": {
     "directive": "MyST {figure} directive with a width (for example width: 70%) and a name",
-    "caption": "One or two sentences describing the figure. No em dashes, and no inline bold or italic in the body text.",
+    "caption": "One or two sentences describing the figure, placed in the page text rather than baked into the image. Avoid em dashes.",
     "credit": "For original handbook figures, no external credit is needed. If the concept is adapted from a source, add a short note such as (Adapted from [Source](url).)"
   },
   "principles": [


### PR DESCRIPTION
Consolidates the handbook figure standard into the contributing guide and a machine-readable spec.

- Filled in the figure color palette and aligned the style guidelines (font, background, size, format) with current practice
- Added figure-format.json in the figures folder as the machine-readable companion, referenced from the contributing guide

Closes #357
