### PR TITLE
Switch link checking to the Jupyter Book linkcheck builder

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,37 +11,51 @@ permissions:
   issues: write
 
 jobs:
-  lychee:
+  linkcheck:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-
-    - name: Run lychee link check
-      id: lychee
-      uses: lycheeverse/lychee-action@v2.8.0
       with:
-        args: >-
-          --verbose
-          --no-progress
-          --max-retries 2
-          --accept 200,203,204,206,429
-          --scheme http
-          --scheme https
-          --base 'https://handbook.eng.kempnerinstitute.harvard.edu'
-          --exclude '^https?://vdi\.rc\.fas\.harvard\.edu/?$'
-          --exclude '^https?://(www\.)?cs\.toronto\.edu/~kriz/cifar\.html$'
-          'kempner_computing_handbook/**/*.md'
-          'README.md'
-          'CONTRIBUTING.md'
-        fail: false
-        output: ./lychee-report.md
+        # Full history so sphinx-last-updated-by-git can read each page's commit date.
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        enable-cache: true
+
+    - name: Run Jupyter Book link check
+      # The Sphinx linkcheck builder resolves internal cross-references from the
+      # built doctree, so it reports only genuinely broken links, not the false
+      # positives a raw markdown checker produces.
+      run: uv run jupyter-book build kempner_computing_handbook --builder linkcheck
+      continue-on-error: true
+
+    - name: Collect broken links
+      id: collect
+      run: |
+        out=$(find kempner_computing_handbook/_build -name output.txt 2>/dev/null | head -1)
+        {
+          echo "# Link Checker Report"
+          echo
+          echo "Broken links reported by the Sphinx linkcheck builder (run via Jupyter Book)."
+          echo
+          echo '```text'
+          grep -F '[broken]' "$out" 2>/dev/null || true
+          echo '```'
+        } > linkcheck-report.md
+        if grep -qF '[broken]' "$out" 2>/dev/null; then
+          echo "has_broken=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_broken=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Open or update link-check issue
-      if: steps.lychee.outputs.exit_code != 0
+      if: steps.collect.outputs.has_broken == 'true'
       uses: peter-evans/create-issue-from-file@v6.0.0
       with:
         title: Link Checker Report
-        content-filepath: ./lychee-report.md
+        content-filepath: ./linkcheck-report.md
         labels: |
           automation
           link-check

--- a/kempner_computing_handbook/_config.yml
+++ b/kempner_computing_handbook/_config.yml
@@ -58,6 +58,21 @@ sphinx:
     ogp_site_name: Kempner Institute Computing Handbook
     sitemap_url_scheme: "{link}"
     mermaid_version: "11.12.1"
+    # Link checking (run via: jupyter-book build ... --builder linkcheck).
+    linkcheck_anchors: false
+    linkcheck_retries: 2
+    linkcheck_timeout: 30
+    linkcheck_allowed_redirects:
+      '.*': '.*'
+    linkcheck_ignore:
+      # Harvard-internal hosts that do not resolve or negotiate TLS off-network.
+      - 'https?://vdi\.rc\.fas\.harvard\.edu'
+      - 'https?://vpn\.rc\.fas\.harvard\.edu'
+      # Hosts that block automated requests (work fine in a browser).
+      - 'https?://(www\.)?huit\.harvard\.edu'
+      - 'https?://(www\.)?dataverse\.org'
+      - 'https?://(www\.)?acm\.org'
+      - 'https?://wiki\.lustre\.org'
     blog_path: "technical_blog/README"
     blog_default_author: max_shad
     blog_authors:

--- a/kempner_computing_handbook/s1_high_performance_computing/development_and_runtime_envs/handling_dependencies_with_spack.md
+++ b/kempner_computing_handbook/s1_high_performance_computing/development_and_runtime_envs/handling_dependencies_with_spack.md
@@ -64,5 +64,5 @@ A list of useful Spack environment commands,
 
 
 ```{tip}
-A complete list of over 5,064 packages in Spack can be found on this [page](https://spack.readthedocs.io/en/v0.16.2/package_list.html). Read more about Spack [here](https://spack.readthedocs.io/en/latest/index.html).
+A complete list of Spack packages can be found on this [page](https://packages.spack.io). Read more about Spack [here](https://spack.readthedocs.io/en/latest/index.html).
 ```

--- a/kempner_computing_handbook/s1_high_performance_computing/development_and_runtime_envs/using_vscode_for_remote_development.md
+++ b/kempner_computing_handbook/s1_high_performance_computing/development_and_runtime_envs/using_vscode_for_remote_development.md
@@ -12,7 +12,7 @@ You must install VSCode on your local machine and also ensure the Remote - SSH e
 - [Remote Explorer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-explorer)
 
 ```{note}
-Please see [Install Visual Studio Code extensions](https://code.visualstudio.com/learn/get-started/extensions) for installing the extensions.
+Please see [Install Visual Studio Code extensions](https://code.visualstudio.com/docs/configure/extensions/extensions) for installing the extensions.
 ```
 
 ## Connecting to the FASRC cluster (login node)

--- a/kempner_computing_handbook/s1_high_performance_computing/storage_and_data_transfer/data_transfer.md
+++ b/kempner_computing_handbook/s1_high_performance_computing/storage_and_data_transfer/data_transfer.md
@@ -140,7 +140,7 @@ You can also submit a job to run `fpsync` and set the number of concurrent jobs 
 srun -c $SLURM_CPUS_PER_TASK fpsync -n $SLURM_CPUS_PER_TASK -t /temp/directory /source/directory /destination/directory
 ```
 
-Refer to the [fpsync documentation](https://manpages.ubuntu.com/manpages/bionic/man1/fpsync.1.html) for further information and additional argument options.
+Refer to the [fpsync documentation](https://docs.rc.fas.harvard.edu/kb/transferring-data-on-the-cluster/) for further information and additional argument options.
 
 :::
 

--- a/kempner_computing_handbook/s5_ai_scaling_and_engineering/scalability/introduction_to_parallel_computing.md
+++ b/kempner_computing_handbook/s5_ai_scaling_and_engineering/scalability/introduction_to_parallel_computing.md
@@ -36,7 +36,7 @@ MPI Workflow Diagram (*Credit: [hpc.nmsu.edu](https://hpc.nmsu.edu/discovery/mpi
 height: 300px
 name: OpenMP Architecture Diagram
 ---
-OpenMP Architecture Diagram (*Credit: [nersc.gov](https://docs.nersc.gov/development/programming-models/openmp/)*)
+OpenMP Architecture Diagram (*Credit: [nersc.gov](https://docs.nersc.gov/development/openmp/)*)
 ```
 
 **CUDA (Compute Unified Device Architecture)**: A parallel computing platform and application programming interface (API) model created by NVIDIA. It allows software developers to use a CUDA-enabled graphics processing unit (GPU) for general purpose processing.


### PR DESCRIPTION
Replace the lychee link checker with the Jupyter Book linkcheck builder, so the weekly report is trustworthy instead of mostly false positives.

- The workflow now runs jupyter-book build with the linkcheck builder, keeping the weekly schedule and the issue report.
- Config ignores only anti-bot and internal-network hosts and allows redirects.
- Fix the four broken links it surfaced (VS Code extensions, NERSC OpenMP, fpsync, Spack package list), each verified.

Closes #370
Closes #365