### PR TITLE
Improve Support and Troubleshooting landing page and FAQ format

### DIFF
--- a/kempner_computing_handbook/s8_support/README.md
+++ b/kempner_computing_handbook/s8_support/README.md
@@ -20,7 +20,7 @@ When you run into difficulties, choose the resource that fits your question:
 
 - **FASRC and general HPC issues** (the cluster, accounts, storage, SLURM): open a ticket with the [FASRC Help Desk](https://portal.rc.fas.harvard.edu/login/?next=/rcrt/tickets/), or simply email [rchelp@rc.fas.harvard.edu](mailto:rchelp@rc.fas.harvard.edu).
 - **Kempner-specific questions** (workflows, community advice): use the `#cluster-users` channel in the Kempner Slack space. To get access, contact [Nikki Shawn](https://kempnerinstitute.harvard.edu/people/our-people/nikki-shawn/).
-- **In-person help**: the Kempner Research Engineering Team holds office hours on Tuesdays and Thursdays from 1 to 2 pm in the Kempner Conference Room. Sessions are listed on the [Kempner community calendar](https://kempnerinstitute.harvard.edu/kempner-community/community-calendar/).
+- **In-person help**: the Kempner Research Engineering Team holds office hours on Tuesdays and Thursdays from 1 to 2 pm in the Kempner Conference Room. Sign up with the [office hours intake form](https://forms.gle/W7HtBzGALSKeYLpD6) so the team can plan for your visit or arrange a Zoom. Sessions are listed on the [Kempner community calendar](https://kempnerinstitute.harvard.edu/kempner-community/community-calendar/).
 - **Still stuck**: if these resources do not resolve your issue, reach out to [Max Shad](https://kempnerinstitute.harvard.edu/people/our-people/max-shad/).
 
 ```{seealso}

--- a/kempner_computing_handbook/s8_support/README.md
+++ b/kempner_computing_handbook/s8_support/README.md
@@ -1,12 +1,32 @@
+(support_and_troubleshooting)=
 # Support and Troubleshooting
 
-If you are new to the FASRC cluster, we recommend taking the FASRC new users training: 
-  - https://www.rc.fas.harvard.edu/upcoming-training/. 
-You can also watch a pre-recorded version: 
-  - https://docs.rc.fas.harvard.edu/wp-content/uploads/fasrc-getting-started-23-mar-2022.mp4 ,  
-or look at their online documentation and training videos: 
-  - https://docs.rc.fas.harvard.edu/kb/quickstart-guide/. 
-  
-FASRC also hosts other workshops that may be of interest. Additionally, FASRC holds zoom office hours every Wednesday from 12 - 3 pm.
+This page points you to the right place for help with the Kempner AI Cluster and the FASRC environment it runs on, from getting-started training to direct support.
 
-For further support, If you are encountering difficulties with the cluster, contacting the [FASRC Help desk](https://portal.rc.fas.harvard.edu/login/?next=/rcrt/tickets/) is often a great resource. You can also reach out to the `#cluster-users` channel in the Kempner Slack space for Kempner-cluster specific questions, concerns, and advice. For access to this Slack channel, please contact [Nikki Shawn](https://kempnerinstitute.harvard.edu/people/our-people/nikki-shawn/). Should these resources not address your needs or if you have additional inquiries, reaching out to [Max Shad](https://kempnerinstitute.harvard.edu/people/our-people/max-shad/) is recommended. If you have suggestions for updates to this user guide, posting them in the #cluster-users channel in the Kempner Slack space is encouraged.
+## New to the cluster
+
+If you are new to the FASRC cluster, start with FASRC's training and documentation:
+
+- [FASRC new-user training](https://www.rc.fas.harvard.edu/upcoming-training/), for live sessions.
+- [Getting started on FASRC clusters (recording)](https://www.youtube.com/watch?v=FdjSJh7jo_U), a recent recorded introduction.
+- [FASRC training materials](https://docs.rc.fas.harvard.edu/kb/training-materials/), slides and recordings for all sessions.
+- [FASRC Quickstart Guide](https://docs.rc.fas.harvard.edu/kb/quickstart-guide/), for online documentation.
+
+FASRC also hosts other workshops, and holds [Zoom office hours](https://www.rc.fas.harvard.edu/office-hours/) every Wednesday from 12 to 3 pm.
+
+## Getting help
+
+When you run into difficulties, choose the resource that fits your question:
+
+- **FASRC and general HPC issues** (the cluster, accounts, storage, SLURM): open a ticket with the [FASRC Help Desk](https://portal.rc.fas.harvard.edu/login/?next=/rcrt/tickets/), or simply email [rchelp@rc.fas.harvard.edu](mailto:rchelp@rc.fas.harvard.edu).
+- **Kempner-specific questions** (workflows, community advice): use the `#cluster-users` channel in the Kempner Slack space. To get access, contact [Nikki Shawn](https://kempnerinstitute.harvard.edu/people/our-people/nikki-shawn/).
+- **In-person help**: the Kempner Research Engineering Team holds office hours on Tuesdays and Thursdays from 1 to 2 pm in the Kempner Conference Room. Sessions are listed on the [Kempner community calendar](https://kempnerinstitute.harvard.edu/kempner-community/community-calendar/).
+- **Still stuck**: if these resources do not resolve your issue, reach out to [Max Shad](https://kempnerinstitute.harvard.edu/people/our-people/max-shad/).
+
+```{seealso}
+Check the {doc}`FAQ <faq>` first for common issues and their fixes.
+```
+
+## Suggesting updates
+
+Have a correction or an addition for this handbook? Post it in the `#cluster-users` channel in the Kempner Slack space so we can keep the guide current.

--- a/kempner_computing_handbook/s8_support/faq.md
+++ b/kempner_computing_handbook/s8_support/faq.md
@@ -1,36 +1,53 @@
+(support_and_troubleshooting:faq)=
 # FAQ
 
-1. I am trying to clone a repository on HPC but I get the following error:
+Answers to common questions, grouped by topic. Select a question to expand its answer. To suggest a new entry, use the `#cluster-users` channel in the Kempner Slack space (see {doc}`Support and Troubleshooting <README>`) or open an issue in the [computing handbook GitHub repository](https://github.com/KempnerInstitute/kempner-computing-handbook/issues).
 
-    ```bash
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
-    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
-    Someone could be eavesdropping on you right now (man-in-the-middle attack)!
-    It is also possible that a host key has just been changed.
-    The fingerprint for the RSA key sent by the remote host is
-    ...
-    ```
-    
-    This can happen if you do not add your ssh key to your github account. Follow these links to add your ssh key to your github account:
-    - [Checking for existing SSH keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)
-    - [Generating a new SSH key and adding it to the ssh-agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=linux)
-    - [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+## Git and GitHub
 
+:::{dropdown} Cloning a repository fails with a "REMOTE HOST IDENTIFICATION HAS CHANGED" warning
+When you try to clone a repository, you see an error like:
 
-2. I am trying to `git push` (`git pull` or `git fetch`) however I get the following error: 
+```text
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+It is also possible that a host key has just been changed.
+The fingerprint for the RSA key sent by the remote host is
+...
+```
 
-    ```bash
-    (gnome-ssh-askpass:134672): Gtk-WARNING **: 07:19:13.800: cannot open display: 
-    error: unable to read askpass response from '/usr/libexec/openssh/gnome-ssh-askpass'
-    Username for 'https://github.com':
-    ```
+This means the host key the server now presents does not match the one cached in your `~/.ssh/known_hosts` file, for example after GitHub rotated its SSH host keys. Remove the stale entry and reconnect to accept the new key:
 
-    This error is due to the fact that you are trying to use `https` instead of `ssh`. You can change the remote url to `ssh` by running the following command:
+```bash
+ssh-keygen -R github.com
+```
 
-    ```bash
-    git remote set-url origin git@github.com:[Github account]/[Github repository].git
-    ```
+The next connection prompts you to accept the new key. Verify its fingerprint against [GitHub's published SSH key fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) before accepting.
 
-    Replace `[Github account]` with your github account and `[Github repository]` with the repository you are trying to push to.
+If you instead see `Permission denied (publickey)`, your SSH key is not registered with your GitHub account. Add it using these guides:
+
+- [Checking for existing SSH keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)
+- [Generating a new SSH key and adding it to the ssh-agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=linux)
+- [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+:::
+
+:::{dropdown} `git push`, `pull`, or `fetch` prompts for a username or shows an askpass error
+When you run `git push`, `git pull`, or `git fetch`, you see an error like:
+
+```text
+(gnome-ssh-askpass:134672): Gtk-WARNING **: 07:19:13.800: cannot open display:
+error: unable to read askpass response from '/usr/libexec/openssh/gnome-ssh-askpass'
+Username for 'https://github.com':
+```
+
+This happens because the repository's remote uses `https` instead of `ssh`. Switch the remote to SSH:
+
+```bash
+git remote set-url origin git@github.com:[Github account]/[Github repository].git
+```
+
+Replace `[Github account]` with your GitHub account and `[Github repository]` with the repository you are pushing to.
+:::


### PR DESCRIPTION
Reworks the Support and Troubleshooting section:

- **Landing page**: replaces bare URLs with hyperlinks and organizes the page into New to the cluster, Getting help, and Suggesting updates. Refreshes the stale 2022 getting-started recording with the current FASRC video and training-materials hub, links FASRC office hours, adds the rchelp email and the Kempner Research Engineering Team in-person office hours (community calendar), and cross-links the FAQ.
- **FAQ**: reformats the numbered list into expandable dropdowns grouped by category (Git and GitHub), scalable as more entries are added. Corrects the git host-key entry, which previously mis-diagnosed a host-key mismatch as a missing account SSH key.

All links verified live, and the pages were audited for correctness and conventions.

Closes #399