### PR TITLE
Fill Scalability and Efficiency section landing pages

### DIFF
--- a/kempner_computing_handbook/s5_ai_scaling_and_engineering/efficiency/README.md
+++ b/kempner_computing_handbook/s5_ai_scaling_and_engineering/efficiency/README.md
@@ -1,1 +1,3 @@
 # Efficiency
+
+This section is about doing more with the GPUs you have: training and serving models faster and within tighter memory budgets. It covers training-side efficiency techniques (mixed precision, memory savings, faster kernels, and efficient fine-tuning), how to monitor a running job and diagnose its bottleneck, and how to deploy and serve models efficiently at inference time.

--- a/kempner_computing_handbook/s5_ai_scaling_and_engineering/scalability/README.md
+++ b/kempner_computing_handbook/s5_ai_scaling_and_engineering/scalability/README.md
@@ -1,3 +1,3 @@
-# Scalability 
+# Scalability
 
-[Addresses strategies for scaling applications, from parallel computing fundamentals to leveraging GPUs for computational tasks.]
+This section covers how to scale machine learning and scientific workloads on the cluster, from the fundamentals of parallel computing to running across many GPUs. It introduces parallel computing concepts, how GPUs accelerate computation and how to profile them, the distributed training strategies (data, model, tensor, pipeline, and fully sharded parallelism), and parallel I/O for keeping the GPUs fed with data.


### PR DESCRIPTION
Replaces the empty Efficiency landing page and the Scalability bracket placeholder with short intros that describe what each section covers, based on their subpages (parallel computing, GPU computing and profiling, distributed training, and parallel I/O for Scalability; training-side efficiency, performance monitoring, and deployment and inference for Efficiency).

Closes #403