### PR TITLE
Expand agent security guidance with task-scoped authority review

### DIFF
--- a/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
+++ b/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
@@ -160,7 +160,7 @@ Your account's authority is not the same as the authority a single task needs. Y
 
 ### Prefer enforceable boundaries over prompt instructions
 
-A prompt such as "do not read files outside this directory" guides the model, but it is not an independent boundary and may not hold under adversarial input. Where the environment allows, prefer limits enforced outside the model: filesystem permissions, {doc}`Slurm resource limits <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`, tool permission allowlists (see {doc}`Configuring Agents for Your Project <configuring_agents>`), and read-only subagents. Use both layers together: enforceable controls set the hard limit, and prompt instructions guide behavior within it.
+A prompt such as "do not read files outside this directory" guides the model, but it is not an independent boundary and may not hold under adversarial input. Where the environment allows, prefer limits enforced outside the model: filesystem permissions, SLURM resource limits (see {doc}`Job Submission Basics <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`), tool permission allowlists (see {doc}`Configuring Agents for Your Project <configuring_agents>`), and read-only subagents. Use both layers together: enforceable controls set the hard limit, and prompt instructions guide behavior within it.
 
 ### Before an unattended run
 
@@ -176,10 +176,10 @@ Before running an agent unattended, work through this checklist. A "no" or "unkn
 | **Data policy** | Is every dataset the agent may read permitted in this environment under the applicable data-use agreement and data level? See {doc}`Security and Compliance <../s6_security_and_compliance/README>`. |
 | **Untrusted input** | Could it read web pages, papers, repository files, datasets, code comments, or tool output that may carry adversarial instructions? See Agent security above. |
 | **Resource scope** | Are CPU, memory, GPU, wall time, and job concurrency bounded to what the task needs, and are autonomous loops capped? |
-| **Execution evidence** | Will enough metadata exist to reconstruct the run, such as the Slurm job ID, code or image version, timestamps, and input and output locations, without logging secrets? |
+| **Execution evidence** | Will enough metadata exist to reconstruct the run, such as the SLURM job ID, code or image version, timestamps, and input and output locations, without logging secrets? |
 | **Stop condition** | What event should make the agent halt and return control to a person rather than widen its own scope? |
 
-When an unattended agent finds it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and ask for human review rather than widen its own scope. Set stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause.
+When an unattended agent finds it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and ask for human review rather than widen its own scope. Set the stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause rather than proceed.
 
 ### Container filesystem visibility
 

--- a/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
+++ b/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
@@ -158,6 +158,24 @@ For the risk categories and defenses in depth, see OWASP's [Top 10 for Agentic A
 
 Your account's authority is not the same as the authority a single task needs. Your account may legitimately reach many projects, directories, credentials, and services, but one agent task usually needs only a small part of that. Because an agent runs as your own process, not as a separate user, it can use whatever files, tools, and credentials that process can reach. If a bug, a bad input, or a prompt-injection payload misdirects it, the reach of the damage is everything the process can touch, not just what the task required. The question to ask is not only whether an action is allowed under your account, but whether the task has more effective authority than its purpose requires.
 
+```{mermaid}
+flowchart TB
+    subgraph ACCT["Account authority"]
+        subgraph NEED["What the task needs"]
+            AG(["Agent"])
+        end
+        EXCESS["Everything else the account can reach:<br/>the blast radius if the agent is misdirected"]
+    end
+    style ACCT fill:#C6C8F4,color:#14154C,stroke:#14154C
+    style NEED fill:#14154C,color:#ffffff,stroke:#3D3E82
+    classDef excess fill:#A51C30,color:#ffffff,stroke:#A51C30;
+    classDef agent fill:#ffffff,color:#14154C,stroke:#14154C;
+    class EXCESS excess;
+    class AG agent;
+```
+
+The goal is to shrink the agent's effective authority toward the inner box, so a misdirected agent can reach little more than the task required.
+
 ### Prefer enforceable boundaries over prompt instructions
 
 A prompt such as "do not read files outside this directory" guides the model, but it is not an independent boundary and may not hold under adversarial input. Where the environment allows, prefer limits enforced outside the model: filesystem permissions, SLURM resource limits (see {doc}`Job Submission Basics <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`), tool permission allowlists (see {doc}`Configuring Agents for Your Project <configuring_agents>`), and read-only subagents. Use both layers together: enforceable controls set the hard limit, and prompt instructions guide behavior within it.
@@ -181,9 +199,43 @@ Before running an agent unattended, work through this checklist. A "no" or "unkn
 
 When an unattended agent finds it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and ask for human review rather than widen its own scope. Set the stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause rather than proceed.
 
+```{mermaid}
+flowchart LR
+    A["Agent needs something<br/>outside its declared task"] --> B{"Response"}
+    B -->|fail closed| STOP["Stop and request<br/>human review"]
+    B -->|avoid| EXPAND["Widen its own scope<br/>and continue"]
+    classDef n fill:#14154C,color:#ffffff,stroke:#3D3E82;
+    classDef good fill:#C6C8F4,color:#14154C,stroke:#14154C;
+    classDef bad fill:#A51C30,color:#ffffff,stroke:#A51C30;
+    class A,B n;
+    class STOP good;
+    class EXPAND bad;
+```
+
 ### Container filesystem visibility
 
 Running an agent inside a Singularity or Apptainer container does not by itself limit what it can read or write on the host. On the cluster, containers bind-mount `/n` (home, lab, and scratch space), the current working directory, and `/tmp` by default, so a containerized agent sees the same files as a non-containerized one unless you restrict the bind mounts. Check your container's effective filesystem visibility rather than assuming it is isolated. See {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for bind-mount behavior.
+
+```{mermaid}
+flowchart LR
+    subgraph HOST["Cluster host filesystem"]
+        N["/n<br/>home, lab, scratch"]
+        PWD["current working<br/>directory"]
+        TMP["/tmp"]
+    end
+    subgraph CONT["Singularity / Apptainer container"]
+        AG(["Agent process"])
+    end
+    N -.->|bound by default| AG
+    PWD -.->|bound by default| AG
+    TMP -.->|bound by default| AG
+    style HOST fill:#C6C8F4,color:#14154C,stroke:#14154C
+    style CONT fill:#14154C,color:#ffffff,stroke:#3D3E82
+    classDef path fill:#ffffff,color:#14154C,stroke:#3D3E82;
+    classDef agent fill:#A51C30,color:#ffffff,stroke:#A51C30;
+    class N,PWD,TMP path;
+    class AG agent;
+```
 
 ## Common pitfalls
 

--- a/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
+++ b/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
@@ -154,6 +154,37 @@ The core habit is to treat everything the agent reads, including tool output, as
 
 For the risk categories and defenses in depth, see OWASP's [Top 10 for Agentic Applications](https://genai.owasp.org/agentic-security-initiative/) and [Top 10 for LLM Applications](https://genai.owasp.org/llm-top-10/); the latter ranks prompt injection first. For cluster data rules, see {doc}`Security and Compliance <../s6_security_and_compliance/README>`.
 
+## Scoping an agent to its task
+
+Your account's authority is not the same as the authority a single task needs. Your account may legitimately reach many projects, directories, credentials, and services, but one agent task usually needs only a small part of that. Because an agent runs as your own process, not as a separate user, it can use whatever files, tools, and credentials that process can reach. If a bug, a bad input, or a prompt-injection payload misdirects it, the reach of the damage is everything the process can touch, not just what the task required. The question to ask is not only whether an action is allowed under your account, but whether the task has more effective authority than its purpose requires.
+
+### Prefer enforceable boundaries over prompt instructions
+
+A prompt such as "do not read files outside this directory" guides the model, but it is not an independent boundary and may not hold under adversarial input. Where the environment allows, prefer limits enforced outside the model: filesystem permissions, {doc}`Slurm resource limits <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`, tool permission allowlists (see {doc}`Configuring Agents for Your Project <configuring_agents>`), and read-only subagents. Use both layers together: enforceable controls set the hard limit, and prompt instructions guide behavior within it.
+
+### Before an unattended run
+
+Before running an agent unattended, work through this checklist. A "no" or "unknown" answer does not by itself block the job; it flags a boundary to resolve first.
+
+| Question | What to check |
+|---|---|
+| **Task boundary** | Can you state in one or two sentences exactly what the agent is meant to do? |
+| **Read scope** | Which files and directories must it read? What unrelated locations can the process also see? |
+| **Write scope** | Where may it create or change files? Can it reach shared environments, checkpoints, datasets, or repositories the task does not need to change? |
+| **Credentials** | Which API tokens, SSH keys, cloud credentials, or authenticated sessions can the process reach? |
+| **Network** | Which external endpoints does the task actually require? |
+| **Data policy** | Is every dataset the agent may read permitted in this environment under the applicable data-use agreement and data level? See {doc}`Security and Compliance <../s6_security_and_compliance/README>`. |
+| **Untrusted input** | Could it read web pages, papers, repository files, datasets, code comments, or tool output that may carry adversarial instructions? See Agent security above. |
+| **Resource scope** | Are CPU, memory, GPU, wall time, and job concurrency bounded to what the task needs, and are autonomous loops capped? |
+| **Execution evidence** | Will enough metadata exist to reconstruct the run, such as the Slurm job ID, code or image version, timestamps, and input and output locations, without logging secrets? |
+| **Stop condition** | What event should make the agent halt and return control to a person rather than widen its own scope? |
+
+When an unattended agent finds it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and ask for human review rather than widen its own scope. Set stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause.
+
+### Container filesystem visibility
+
+Running an agent inside a Singularity or Apptainer container does not by itself limit what it can read or write on the host. On the cluster, containers bind-mount `/n` (home, lab, and scratch space), the current working directory, and `/tmp` by default, so a containerized agent sees the same files as a non-containerized one unless you restrict the bind mounts. Check your container's effective filesystem visibility rather than assuming it is isolated. See {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for bind-mount behavior.
+
 ## Common pitfalls
 
 - The agent tries to `sudo`, install system packages, or modify files outside your space. You do not have root on the cluster; keep changes within your own directories and environments.

--- a/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
+++ b/kempner_computing_handbook/s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster.md
@@ -214,7 +214,7 @@ flowchart LR
 
 ### Container filesystem visibility
 
-Running an agent inside a Singularity or Apptainer container does not by itself limit what it can read or write on the host. On the cluster, containers bind-mount `/n` (home, lab, and scratch space), the current working directory, and `/tmp` by default, so a containerized agent sees the same files as a non-containerized one unless you restrict the bind mounts. Check your container's effective filesystem visibility rather than assuming it is isolated. See {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for bind-mount behavior.
+Running an agent inside a Singularity or Apptainer container does not by itself isolate it from the host filesystem. On the cluster, the default configuration makes `/n` (home, lab, and scratch space), your current working directory, and `/tmp` available inside the container, so unless you opt into isolation a containerized agent sees the same files as a non-containerized one. You control this: restrict what is mounted with options such as `--contain` or `--no-mount`, and add only the paths the task needs with `--bind`. Verify your container's effective filesystem visibility rather than assuming it is isolated. See {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for bind-mount behavior.
 
 ```{mermaid}
 flowchart LR

--- a/kempner_computing_handbook/s6_security_and_compliance/README.md
+++ b/kempner_computing_handbook/s6_security_and_compliance/README.md
@@ -82,7 +82,7 @@ Agentic tools are also exposed to prompt injection: untrusted content the agent 
 ```
 
 ```{note}
-Scope an autonomous agent to its task. An agent runs with your account's authority, which usually exceeds what any single task needs. Reduce a task's effective authority to match its purpose using controls that do not depend on the model, such as filesystem permissions, resource limits, and tool allowlists, and prefer stopping for human review over letting an agent widen its own scope. See {doc}`Using Agentic AI on the Cluster <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>` for how to do this.
+Scope an autonomous agent to its task. An agent runs with your account's authority, which usually exceeds what any single task needs, so reduce its effective authority to match the task's purpose using controls that do not depend on the model. When scope is ambiguous, prefer stopping for human review over letting the agent widen its own scope. See {doc}`Using Agentic AI on the Cluster <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>` for how to do this.
 ```
 
 ```{warning}
@@ -183,8 +183,8 @@ If you suspect a security incident, a compromised account, or a policy violation
 ```{note}
 **If an autonomous agent behaves unexpectedly**, the reporting guidance above applies, with these agent-specific steps:
 
-1. Stop the agent or job first. Cancel the Slurm job or terminate the process before investigating.
-2. Preserve run metadata. Save the Slurm job ID, logs, and relevant output, without copying secrets into new files.
+1. Stop the agent or job first. Cancel the SLURM job or terminate the process before investigating.
+2. Preserve run metadata. Save the SLURM job ID, logs, and relevant output, without copying secrets into new files.
 3. Rotate exposed credentials. If the agent may have read or transmitted API keys, tokens, or other secrets, revoke and rotate them.
 4. Escalate when appropriate. If shared data, other users' resources, cluster stability, or a data-use agreement may be affected, report it to your PI and to FASRC.
 5. Do not use the same agent to investigate. An agent that may have been misdirected should not assess its own behavior.

--- a/kempner_computing_handbook/s6_security_and_compliance/README.md
+++ b/kempner_computing_handbook/s6_security_and_compliance/README.md
@@ -89,63 +89,6 @@ Scope an autonomous agent to its task. An agent runs with your account's authori
 **Prohibited AI under the NDAA.** Harvard's [NDAA 2026 Guidance and Prohibition on use of certain Artificial Intelligence](https://bpb-us-e1.wpmucdn.com/websites.harvard.edu/dist/f/106/files/2026/01/NDAA-2026-Guidance-and-Prohibition-on-use-of-certain-Artificial-Intelligence.pdf) prohibits anyone performing work under a U.S. Department of Defense (DoD) contract from using AI developed by **DeepSeek**, its parent company High Flyer, or affiliated entities, in any activity related to that contract. The prohibition covers faculty, staff, students, and visitors working on the contract, and it applies to self-hosting the open-weight DeepSeek models on the cluster as well as the hosted service. If your work is, or may be, under a DoD contract, do not use these tools, and contact the Office of the Vice Provost for Research if you are unsure whether the policy applies to you.
 ```
 
-## Task-scoped authority for autonomous agents
-
-The guidance above applies to every AI tool. This section adds a narrower point for jobs that run autonomously or semi-autonomously: your account's authority is not the same as the authority a single task needs.
-
-A researcher's account may legitimately access many projects, directories, credentials, and services. An autonomous agent job typically needs only a subset of that access for one task. Because the agent is not a separate Unix principal — it runs as your process — it can exercise whatever files, tools, and credentials the surrounding process exposes. If the agent is misdirected by a bug, a bad input, or a prompt-injection payload, the blast radius is everything the process can reach, not just what the task required.
-
-The security question is therefore not only *"is this action authorized under my account?"* but also *"does this autonomous task have more effective authority than its stated research purpose requires?"*
-
-### Prefer enforceable boundaries over prompt instructions
-
-A prompt such as "do not access files outside this directory" is behavioral guidance to the model. It is useful as an additional guardrail, but it is not an independent security boundary — the model may not honor it under adversarial input or unexpected context.
-
-Where the environment supports it, prefer restrictions enforced outside the model: file and directory permissions, {doc}`Slurm resource limits <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`, tool permission allowlists (see {doc}`Configuring Agents <../s5b_agentic_ai_workflows/configuring_agents>`), and read-only subagent scoping. These controls operate independently of what the model decides to do.
-
-```{note}
-This does not mean prompt-level instructions are worthless. It means they are a layer, not the whole boundary. Use both: enforceable controls to set the hard limit, and model instructions to guide normal behavior within that limit.
-```
-
-### Pre-submission task-boundary review
-
-Before running an autonomous or semi-autonomous job unattended, work through the following checklist. A "no" or "unknown" answer does not necessarily prohibit the job — it means the unresolved boundary should be reviewed before unattended execution.
-
-| Question | What to check |
-|---|---|
-| **Task boundary** | Can you state in one or two sentences exactly what this agent is supposed to do? |
-| **Read scope** | Which files and directories must it read? What unrelated locations can the process also see? |
-| **Write scope** | Where may it create or modify files? Can it reach shared environments, checkpoints, datasets, or repositories that the task does not need to change? |
-| **Credentials** | Which API tokens, SSH keys, cloud credentials, or authenticated sessions are reachable by the process? |
-| **Network and external services** | Which external endpoints does the task actually require? If you need to restrict outbound access beyond what the task requires, check with [FASRC](https://docs.rc.fas.harvard.edu/kb/acceptable-use/) for available options. |
-| **Data policy** | Is every dataset the agent may read permitted in this environment under the applicable data-use agreement and {ref}`data classification <security_and_compliance>`? |
-| **Untrusted input** | Could it consume web pages, papers, repository files, datasets, code comments, tool output, or shared content that may contain adversarial instructions? See {doc}`Agent Security <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>` for prompt-injection background. |
-| **Resource scope** | Are CPU, memory, GPU, wall time, and job concurrency bounded to what the task needs? Are autonomous loops capped? |
-| **Execution evidence** | Will enough metadata exist to reconstruct the run — Slurm job ID, code or image version, timestamps, input and output locations — without logging secrets? |
-| **Stop condition** | What event should cause the agent to halt and return control to a human rather than expanding its own scope? |
-
-```{tip}
-A useful mental test: *"If this agent were redirected by a bad input, what could it do with the authority it already has?"* The answer should be close to the delegated research task, not the full capability of your account.
-```
-
-### Fail closed on scope ambiguity
-
-When an unattended agent discovers it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and request human review — not to expand its own scope autonomously. Configure stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause, not to proceed.
-
-### Container filesystem visibility
-
-Running a process inside a Singularity/Apptainer container does not automatically restrict what it can read or write on the host. On the FASRC cluster, containers bind-mount `/n` (home, lab, and scratch space), the current working directory, and `/tmp` by default, so a containerized agent can see and modify the same files as a non-containerized one unless you explicitly restrict the bind mounts. Verify the effective filesystem visibility of your container rather than assuming isolation. See the handbook's {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` guide and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for details on bind-mount behavior.
-
-### If an agent behaves unexpectedly
-
-The {ref}`Reporting a concern <security_and_compliance>` guidance below applies generally. For an autonomous agent job specifically:
-
-1. **Stop the agent or job first** — cancel the Slurm job or terminate the process before investigating.
-2. **Preserve run metadata** — save the Slurm job ID, logs, and relevant output without copying secrets into new files.
-3. **Rotate exposed credentials** — if the agent may have read or transmitted API keys, tokens, or other secrets, revoke and rotate them.
-4. **Escalate when appropriate** — if shared data, other users' resources, cluster stability, or a data-use agreement may be affected, report it to your PI and to FASRC ([rchelp@rc.fas.harvard.edu](mailto:rchelp@rc.fas.harvard.edu)).
-5. **Do not use the same agent to investigate** — a broadly permissioned agent that may have been misdirected should not be given the job of assessing its own behavior.
-
 ## External data and network conduct
 
 Datasets you download or scrape from external providers come with terms of use, and the whole cluster shares a small pool of public IP addresses.

--- a/kempner_computing_handbook/s6_security_and_compliance/README.md
+++ b/kempner_computing_handbook/s6_security_and_compliance/README.md
@@ -81,6 +81,10 @@ An unsupervised agent can delete data or disrupt shared resources far faster tha
 Agentic tools are also exposed to prompt injection: untrusted content the agent reads, such as web pages, files, or datasets, can carry hidden instructions. Treat what an agent reads as data rather than commands, keep a human approving consequential actions, and give the agent least privilege. See OWASP's [Top 10 for Agentic Applications](https://genai.owasp.org/agentic-security-initiative/) and, for running these tools here, {doc}`Using Agentic AI on the Cluster <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>`.
 ```
 
+```{note}
+Scope an autonomous agent to its task. An agent runs with your account's authority, which usually exceeds what any single task needs. Reduce a task's effective authority to match its purpose using controls that do not depend on the model, such as filesystem permissions, resource limits, and tool allowlists, and prefer stopping for human review over letting an agent widen its own scope. See {doc}`Using Agentic AI on the Cluster <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>` for how to do this.
+```
+
 ```{warning}
 **Prohibited AI under the NDAA.** Harvard's [NDAA 2026 Guidance and Prohibition on use of certain Artificial Intelligence](https://bpb-us-e1.wpmucdn.com/websites.harvard.edu/dist/f/106/files/2026/01/NDAA-2026-Guidance-and-Prohibition-on-use-of-certain-Artificial-Intelligence.pdf) prohibits anyone performing work under a U.S. Department of Defense (DoD) contract from using AI developed by **DeepSeek**, its parent company High Flyer, or affiliated entities, in any activity related to that contract. The prohibition covers faculty, staff, students, and visitors working on the contract, and it applies to self-hosting the open-weight DeepSeek models on the cluster as well as the hosted service. If your work is, or may be, under a DoD contract, do not use these tools, and contact the Office of the Vice Provost for Research if you are unsure whether the policy applies to you.
 ```
@@ -174,4 +178,14 @@ Your work is also bound by the requirements of whoever funds and governs it.
 ```{admonition} Reporting a concern
 :class: important
 If you suspect a security incident, a compromised account, or a policy violation, report it promptly. Contact FASRC at [rchelp@rc.fas.harvard.edu](mailto:rchelp@rc.fas.harvard.edu) and, for security incidents, Harvard's Information Security office at [ithelp@harvard.edu](mailto:ithelp@harvard.edu). Acting quickly limits the impact on you, your lab, and the wider cluster.
+```
+
+```{note}
+**If an autonomous agent behaves unexpectedly**, the reporting guidance above applies, with these agent-specific steps:
+
+1. Stop the agent or job first. Cancel the Slurm job or terminate the process before investigating.
+2. Preserve run metadata. Save the Slurm job ID, logs, and relevant output, without copying secrets into new files.
+3. Rotate exposed credentials. If the agent may have read or transmitted API keys, tokens, or other secrets, revoke and rotate them.
+4. Escalate when appropriate. If shared data, other users' resources, cluster stability, or a data-use agreement may be affected, report it to your PI and to FASRC.
+5. Do not use the same agent to investigate. An agent that may have been misdirected should not assess its own behavior.
 ```

--- a/kempner_computing_handbook/s6_security_and_compliance/README.md
+++ b/kempner_computing_handbook/s6_security_and_compliance/README.md
@@ -85,6 +85,63 @@ Agentic tools are also exposed to prompt injection: untrusted content the agent 
 **Prohibited AI under the NDAA.** Harvard's [NDAA 2026 Guidance and Prohibition on use of certain Artificial Intelligence](https://bpb-us-e1.wpmucdn.com/websites.harvard.edu/dist/f/106/files/2026/01/NDAA-2026-Guidance-and-Prohibition-on-use-of-certain-Artificial-Intelligence.pdf) prohibits anyone performing work under a U.S. Department of Defense (DoD) contract from using AI developed by **DeepSeek**, its parent company High Flyer, or affiliated entities, in any activity related to that contract. The prohibition covers faculty, staff, students, and visitors working on the contract, and it applies to self-hosting the open-weight DeepSeek models on the cluster as well as the hosted service. If your work is, or may be, under a DoD contract, do not use these tools, and contact the Office of the Vice Provost for Research if you are unsure whether the policy applies to you.
 ```
 
+## Task-scoped authority for autonomous agents
+
+The guidance above applies to every AI tool. This section adds a narrower point for jobs that run autonomously or semi-autonomously: your account's authority is not the same as the authority a single task needs.
+
+A researcher's account may legitimately access many projects, directories, credentials, and services. An autonomous agent job typically needs only a subset of that access for one task. Because the agent is not a separate Unix principal — it runs as your process — it can exercise whatever files, tools, and credentials the surrounding process exposes. If the agent is misdirected by a bug, a bad input, or a prompt-injection payload, the blast radius is everything the process can reach, not just what the task required.
+
+The security question is therefore not only *"is this action authorized under my account?"* but also *"does this autonomous task have more effective authority than its stated research purpose requires?"*
+
+### Prefer enforceable boundaries over prompt instructions
+
+A prompt such as "do not access files outside this directory" is behavioral guidance to the model. It is useful as an additional guardrail, but it is not an independent security boundary — the model may not honor it under adversarial input or unexpected context.
+
+Where the environment supports it, prefer restrictions enforced outside the model: file and directory permissions, {doc}`Slurm resource limits <../s1_high_performance_computing/general_hpc_concepts/job_submission_basics>`, tool permission allowlists (see {doc}`Configuring Agents <../s5b_agentic_ai_workflows/configuring_agents>`), and read-only subagent scoping. These controls operate independently of what the model decides to do.
+
+```{note}
+This does not mean prompt-level instructions are worthless. It means they are a layer, not the whole boundary. Use both: enforceable controls to set the hard limit, and model instructions to guide normal behavior within that limit.
+```
+
+### Pre-submission task-boundary review
+
+Before running an autonomous or semi-autonomous job unattended, work through the following checklist. A "no" or "unknown" answer does not necessarily prohibit the job — it means the unresolved boundary should be reviewed before unattended execution.
+
+| Question | What to check |
+|---|---|
+| **Task boundary** | Can you state in one or two sentences exactly what this agent is supposed to do? |
+| **Read scope** | Which files and directories must it read? What unrelated locations can the process also see? |
+| **Write scope** | Where may it create or modify files? Can it reach shared environments, checkpoints, datasets, or repositories that the task does not need to change? |
+| **Credentials** | Which API tokens, SSH keys, cloud credentials, or authenticated sessions are reachable by the process? |
+| **Network and external services** | Which external endpoints does the task actually require? If you need to restrict outbound access beyond what the task requires, check with [FASRC](https://docs.rc.fas.harvard.edu/kb/acceptable-use/) for available options. |
+| **Data policy** | Is every dataset the agent may read permitted in this environment under the applicable data-use agreement and {ref}`data classification <security_and_compliance>`? |
+| **Untrusted input** | Could it consume web pages, papers, repository files, datasets, code comments, tool output, or shared content that may contain adversarial instructions? See {doc}`Agent Security <../s5b_agentic_ai_workflows/using_agentic_ai_on_the_cluster>` for prompt-injection background. |
+| **Resource scope** | Are CPU, memory, GPU, wall time, and job concurrency bounded to what the task needs? Are autonomous loops capped? |
+| **Execution evidence** | Will enough metadata exist to reconstruct the run — Slurm job ID, code or image version, timestamps, input and output locations — without logging secrets? |
+| **Stop condition** | What event should cause the agent to halt and return control to a human rather than expanding its own scope? |
+
+```{tip}
+A useful mental test: *"If this agent were redirected by a bad input, what could it do with the authority it already has?"* The answer should be close to the delegated research task, not the full capability of your account.
+```
+
+### Fail closed on scope ambiguity
+
+When an unattended agent discovers it needs data, credentials, external access, or actions outside its declared task, the safe default is to stop and request human review — not to expand its own scope autonomously. Configure stop conditions and loop limits before submission, and treat unexpected scope expansion as a signal to pause, not to proceed.
+
+### Container filesystem visibility
+
+Running a process inside a Singularity/Apptainer container does not automatically restrict what it can read or write on the host. On the FASRC cluster, containers bind-mount `/n` (home, lab, and scratch space), the current working directory, and `/tmp` by default, so a containerized agent can see and modify the same files as a non-containerized one unless you explicitly restrict the bind mounts. Verify the effective filesystem visibility of your container rather than assuming isolation. See the handbook's {doc}`Containerization <../s1_high_performance_computing/development_and_runtime_envs/containerization>` guide and the [FASRC Singularity documentation](https://docs.rc.fas.harvard.edu/kb/singularity-on-the-cluster/) for details on bind-mount behavior.
+
+### If an agent behaves unexpectedly
+
+The {ref}`Reporting a concern <security_and_compliance>` guidance below applies generally. For an autonomous agent job specifically:
+
+1. **Stop the agent or job first** — cancel the Slurm job or terminate the process before investigating.
+2. **Preserve run metadata** — save the Slurm job ID, logs, and relevant output without copying secrets into new files.
+3. **Rotate exposed credentials** — if the agent may have read or transmitted API keys, tokens, or other secrets, revoke and rotate them.
+4. **Escalate when appropriate** — if shared data, other users' resources, cluster stability, or a data-use agreement may be affected, report it to your PI and to FASRC ([rchelp@rc.fas.harvard.edu](mailto:rchelp@rc.fas.harvard.edu)).
+5. **Do not use the same agent to investigate** — a broadly permissioned agent that may have been misdirected should not be given the job of assessing its own behavior.
+
 ## External data and network conduct
 
 Datasets you download or scrape from external providers come with terms of use, and the whole cluster shares a small pool of public IP addresses.


### PR DESCRIPTION
## Summary

- Adds a **Task-scoped authority for autonomous agents** section to the Security and Compliance page
- Introduces the concept that a user account's legitimate authority typically exceeds what any single autonomous task requires, and that the effective authority of an unattended agent job should be reduced to match the delegated task
- Clarifies that prompt-level restrictions (e.g. "do not access files outside this directory") supplement but do not replace enforceable controls such as filesystem permissions, Slurm limits, and tool permission allowlists
- Adds a **pre-submission task-boundary review** checklist covering read/write scope, credentials, network, data policy, untrusted input, resource bounds, execution evidence, and stop conditions
- Adds a **fail-closed** principle: when an unattended agent encounters scope ambiguity, the safe default is to stop and request human review
- Documents **container filesystem visibility**: Singularity/Apptainer containers on FASRC bind-mount `/n`, `$PWD`, and `/tmp` by default, so a containerized agent can see the same files as a non-containerized one unless bind mounts are explicitly restricted (verified against the handbook's own containerization guide and FASRC documentation)
- Adds **agent-specific unexpected-behavior response** steps (stop, preserve metadata, rotate credentials, escalate, do not self-investigate)

## Why

The existing handbook already covers prompt injection, least privilege, human review for consequential actions, and general compliance. This change fills the narrower gap between a user account's legitimate authority and the authority needed by one delegated autonomous task — a delegation problem specific to unattended agent workflows on shared infrastructure.

## Validation

- `git diff --check`: passed (exit 0, no trailing whitespace or merge conflict markers)
- `make build`: passed (`build succeeded`, no warnings introduced by this change)
- Only file changed: `kempner_computing_handbook/s6_security_and_compliance/README.md` (57 insertions)
- Cross-references verified: links to Job Submission Basics, Configuring Agents, Containerization guide, FASRC Singularity docs, FASRC Acceptable Use Policy, and Agentic AI chapter all resolve
- No duplication with existing Agentic AI chapter content (prompt injection, permission modes, subagent scoping, etc.)
- Container default bind-mount claim verified against handbook containerization page (line 183: "By default, `/n` ... your current working directory, and `/tmp` are already available inside the container")